### PR TITLE
More specific FILTER flag

### DIFF
--- a/simple_sv_annotation.py
+++ b/simple_sv_annotation.py
@@ -32,8 +32,8 @@ Current scheme with priority 1(high)-3(low)
 .. on gene list (2)
 .. not on gene list (3)
 - upstream or downstream of gene list genes (3)
-- other variant (REJECT)
-- missing ANN or SVTYPE: REJECT
+- other variant: "Intergenic" in FILTER
+- missing ANN or SVTYPE: "Intergenic" in FILTER
 
 See the provided README.md file for more information
 """
@@ -62,8 +62,8 @@ def main(vcf_in, outfile, exon_nums, args):
 
     # Add filters
     #
-    vcf_reader.filters["SV_Prioritize_PureIntergenic"] = vcf.parser._Filter(id="SV_Prioritize_PureIntergenic", desc="Rejected in SV-prioritize (missing ANN/BND, purely intergenic, a small event)")
-    vcf_writer = vcf.Writer(open(outfile, 'w'), vcf_reader) if outfile !="-" else vcf.Writer(sys.stdout, vcf_reader)
+    vcf_reader.filters["Intergenic"] = vcf.parser._Filter(id="Intergenic", desc="Rejected in SV-prioritize (missing ANN/BND, or purely intergenic, or a small event)")
+    vcf_writer = vcf.Writer(open(outfile, 'w'), vcf_reader) if outfile != "-" else vcf.Writer(sys.stdout, vcf_reader)
     #
     # Read in gene lists
     #
@@ -145,7 +145,7 @@ def simplify_ann(record, exon_nums, known_fusions, prioritised_genes):
         annotated = True
     # REJECT purely intergenic events and other nuisance variants
     if is_intergenic:
-        record.FILTER.append("SV_Prioritize_PureIntergenic")
+        record.FILTER.append("Intergenic")
         del record.INFO["SV_HIGHEST_TIER"]
     return record
 

--- a/simple_sv_annotation.py
+++ b/simple_sv_annotation.py
@@ -62,7 +62,7 @@ def main(vcf_in, outfile, exon_nums, args):
 
     # Add filters
     #
-    vcf_reader.filters["REJECT"] = vcf.parser._Filter(id="REJECT", desc="Rejected due various criteria (missing ANN/BND, purely intergenic, small events)")
+    vcf_reader.filters["SV_Prioritize_PureIntergenic"] = vcf.parser._Filter(id="SV_Prioritize_PureIntergenic", desc="Rejected in SV-prioritize (missing ANN/BND, purely intergenic, a small event)")
     vcf_writer = vcf.Writer(open(outfile, 'w'), vcf_reader) if outfile !="-" else vcf.Writer(sys.stdout, vcf_reader)
     #
     # Read in gene lists
@@ -145,7 +145,7 @@ def simplify_ann(record, exon_nums, known_fusions, prioritised_genes):
         annotated = True
     # REJECT purely intergenic events and other nuisance variants
     if is_intergenic:
-        record.FILTER.append("REJECT")
+        record.FILTER.append("SV_Prioritize_PureIntergenic")
         del record.INFO["SV_HIGHEST_TIER"]
     return record
 
@@ -272,7 +272,7 @@ def create_exon_numDict(infile):
     exons = {}
     f = open(infile)
     for line in f:
-        la = line.rstrip("\n").split("\t");
+        la = line.rstrip("\n").split("\t")
         name = la[3].split("|")
         transcript = name[0]
         if transcript in exons:


### PR DESCRIPTION
When exploring WGS bcbio results, we might want to go back to intergenic events. It's nice when they are soft-filtered, however the `REJECT` tag in sv-prioritize is too generic for downstream filtering tricks. Proposing here to rename it to `SV_Prioritize_PureIntergenic` (this name is arbitrary, feel free to suggest any other one!). So that if I want to get otherwise high-quality intergenic variants, I could do:

```
bcftools view -f.,PASS,SV_Prioritize_PureIntergenic GATM-RAF1-sv-prioritize-manta.vcf.gz
```

cc @ohofmann 